### PR TITLE
Dpavel/chart title fix

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -60,15 +60,16 @@ export default function (props) {
   const metricCount = useSelector((state) => state.charts.metricCount);
   const { client } = useContext(SocketContext);
 
-  const options = useMemo(() => optionsInit, [options]);
+  const chartOptions = Object.assign({}, optionsInit);
+  chartOptions.plugins.title.text = friendlyList[props.metric];
+
   useEffect(() => {
     // Set the title based upon the list of friendly metric names
     // stored in '../utils/metrics
-    options.plugins.title.text = friendlyList[props.metric];
 
     // if we have a props.data, we are loading from historical data
     if (Object.hasOwn(props, 'data')) {
-      options.updateMode = 'none';
+      chartOptions.updateMode = 'none';
 
       const modifiedLabels = [];
       props.data.labels.forEach((label) => {
@@ -247,7 +248,7 @@ export default function (props) {
       ) : (
         <Line
           datasetIdKey={props.metric}
-          options={options}
+          options={chartOptions}
           data={{
             labels: labels,
             datasets: data,

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -102,4 +102,5 @@ export const chartOptionsInit = {
     },
   },
   updateMode: 'active',
+  animation: false,
 };

--- a/ts-server/Controllers/dataController.ts
+++ b/ts-server/Controllers/dataController.ts
@@ -88,7 +88,14 @@ const dataController: object = {
 
     try {
       const filename = formatDate() + '_log.json';
-      filePath = path.resolve(__dirname, `../History/${filename}`);
+      const LOG_DIR_NAME = 'History';
+      const LOG_DIR_PATH = path.resolve(__dirname, '..', LOG_DIR_NAME);
+
+      if (!fs.existsSync(LOG_DIR_PATH)) {
+        fs.mkdirSync(LOG_DIR_PATH);
+      }
+
+      filePath = path.resolve(LOG_DIR_PATH, filename);
       const newData = req.body;
       let fileObj: HistoryObject = {};
 


### PR DESCRIPTION
The history directory will now be created if it doesn't exist.
The chart titles no longer change when opening new charts.
The charts are no longer animated (they change but without animations).